### PR TITLE
Thermal/dptf: Print the key log of DPTF for test

### DIFF
--- a/DPTF/Sources/Policies/PolicyLib/ParticipantProxy.cpp
+++ b/DPTF/Sources/Policies/PolicyLib/ParticipantProxy.cpp
@@ -213,7 +213,7 @@ void ParticipantProxy::setThresholdCrossed(const Temperature& temperature, const
 {
 	m_lastThresholdCrossedTemperature = temperature;
 	m_timeOfLastThresholdCrossed = timestamp;
-	m_policyServices.messageLogging->writeMessageDebug(PolicyMessage(
+	m_policyServices.messageLogging->writeMessageError(PolicyMessage(
 		FLF,
 		"Temperature threshold crossed for participant with temperature " + temperature.toString() + ".",
 		getIndex()));


### PR DESCRIPTION
Logcat no temperature log output, block 1st SW cooling action test.
Print the key log of DPTF for test.

Jira: https://01.org/jira/browse/AIA-420
Test: Test it on Joule.
After boot-up, run "logcat | grep setThresholdCrossed"
and show the key log of temperature.

Signed-off-by: Sun Xinx <xinx.sun@intel.com>